### PR TITLE
Update golang builder image to 1.23

### DIFF
--- a/images/local-csi-driver/Dockerfile
+++ b/images/local-csi-driver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/scylladb/scylla-operator-images:golang-1.22 AS builder
+FROM quay.io/scylladb/scylla-operator-images:golang-1.23 AS builder
 SHELL ["/bin/bash", "-euEo", "pipefail", "-O", "inherit_errexit", "-c"]
 WORKDIR /go/src/github.com/scylladb/local-csi-driver
 COPY . .


### PR DESCRIPTION
This PR updates the Golang builder image to 1.23