### PR TITLE
Switch runtime image to UBI

### DIFF
--- a/images/local-csi-driver/Dockerfile
+++ b/images/local-csi-driver/Dockerfile
@@ -4,13 +4,12 @@ WORKDIR /go/src/github.com/scylladb/local-csi-driver
 COPY . .
 RUN make build --warn-undefined-variables GO_BUILD_PACKAGES=./cmd/local-csi-driver
 
-FROM quay.io/scylladb/scylla-operator-images:base-ubuntu-22.04
+FROM quay.io/scylladb/scylla-operator-images:base-ubi-9.4-minimal
 SHELL ["/bin/bash", "-euEo", "pipefail", "-O", "inherit_errexit", "-c"]
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends xfsprogs && \
-    apt-get clean  && \
-    rm -rf /var/lib/apt/lists/*
+RUN microdnf install -y --enablerepo=almalinux-base-9 xfsprogs && \
+    microdnf clean all && \
+    rm -rf /var/cache/dnf/*
 
 COPY --from=builder /go/src/github.com/scylladb/local-csi-driver/local-csi-driver /usr/bin/
 ENTRYPOINT ["/usr/bin/local-csi-driver"]


### PR DESCRIPTION
This PR switches the runtime image too use UBI, following up on a similar change in our other repos.