### PR TITLE
Bump Go to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scylladb/local-csi-driver
 
-go 1.22.4
+go 1.23
 
 require (
 	github.com/container-storage-interface/spec v1.9.0

--- a/images/local-csi-driver-tests/Dockerfile
+++ b/images/local-csi-driver-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/scylladb/scylla-operator-images:golang-1.22 AS builder
+FROM quay.io/scylladb/scylla-operator-images:golang-1.23 AS builder
 SHELL ["/bin/bash", "-euEo", "pipefail", "-O", "inherit_errexit", "-c"]
 WORKDIR /go/src/github.com/scylladb/local-csi-driver
 COPY . .


### PR DESCRIPTION
Minimal required Go version is set to 1.23.
Test image has been bumped to use it.
Main image is already using it.

Requires:

- [x] https://github.com/scylladb/local-csi-driver/pull/68