### PR TITLE
Use the release GitHub Action from operator `master`

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -43,7 +43,7 @@ jobs:
         echo "current_tag=${current_tag}" | tee -a ${GITHUB_ENV}
     
     - name: Generate and publish release notes
-      uses: scylladb/scylla-operator/.github/actions/release-notes@v1.9.0-alpha.4
+      uses: scylladb/scylla-operator/.github/actions/release-notes@master
       with:
         githubRepository: ${{ github.repository }}
         githubRef: ${{ env.current_tag }}


### PR DESCRIPTION
Remove the `1.9.0-alpha.4` pin for the release GH Action. Use `master` instead.

This is because we need https://github.com/scylladb/scylla-operator/pull/2514 for the 0.5.0 release. Also resolves the future need to track changes manually.

/kind cleanup
/priority important-soon
/cc zimnx rzetelskik