### PR TITLE
Fix time in dependabot's schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   schedule:
     interval: weekly
     day: wednesday
-    time: '5:00' # UTC
+    time: '05:00' # UTC
   labels:
   - priority/important-longterm
   - kind/dependency-bump


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** The current dependabot specification is invalid.
```
The property '#/updates/0/schedule/time' value "5:00" did not match the regex '^\d\d:\d\d$'
```
This PR fixes the time to match the regex.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon