### PR TITLE
Make OWNERS and OWNERS_ALIASES consistent with scylla-operator

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,11 +3,11 @@
 filters:
   ".*":
     approvers:
-    - local-csi-driver-approvers
+    - operator-approvers
     reviewers:
-    - local-csi-driver-reviewers
+    - operator-review-autoassignees
   "go\\.(mod|sum)$":
-    required_reviewers:
-    - local-csi-driver-approvers
+    reviewers:
+    - operator-approvers
     labels:
     - area/dependency

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,13 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 aliases:
-  local-csi-driver-reviewers:
-  - zimnx
-  - rzetelskik
-  - mflendrich
+  operator-team:
+  # All members of the team.
   - czeslavo
-  local-csi-driver-approvers:
-  - zimnx
-  - rzetelskik
   - mflendrich
+  - rzetelskik
+  operator-review-autoassignees:
+  # Subset of operator-team that will be automatically requested for reviews in PRs.
   - czeslavo
+  - rzetelskik
+  operator-approvers:
+  # Subset of operator-team that has "approve" rights.
+  # Rule for adding new members:
+  # Demonstrated meaningful contributions to the majority of the codebase
+  # over a period of at least 6 months, OR a team lead.
+  - mflendrich
+  - rzetelskik


### PR DESCRIPTION
Part of https://github.com/scylladb/scylla-operator-team/issues/20.
Also ports https://github.com/scylladb/scylla-operator/pull/2936 to this repo.

/cc rzetelskik
/priority important-soon